### PR TITLE
Set coverage filters

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source = 
+    slug


### PR DESCRIPTION
Finally set coverage filters, so we only track & report on actual source code.